### PR TITLE
Allow Custom openssl config file

### DIFF
--- a/src/Component/Core/Util/ECKey.php
+++ b/src/Component/Core/Util/ECKey.php
@@ -101,7 +101,7 @@ final class ECKey
         if ($key === false) {
             throw new RuntimeException('Unable to create the key');
         }
-        $result = openssl_pkey_export($key, $out);
+        $result = openssl_pkey_export($key, $out, null, $configArgs);
         if ($result === false) {
             throw new RuntimeException('Unable to create the key');
         }

--- a/src/Component/Core/Util/ECKey.php
+++ b/src/Component/Core/Util/ECKey.php
@@ -90,10 +90,14 @@ final class ECKey
         if (! extension_loaded('openssl')) {
             throw new RuntimeException('Please install the OpenSSL extension');
         }
-        $key = openssl_pkey_new([
+        $configArgs = [
             'curve_name' => self::getOpensslCurveName($curve),
             'private_key_type' => OPENSSL_KEYTYPE_EC,
-        ]);
+        ];
+        if (env('WEB_TOKEN_JWT_FRAMEWORK_USE_OPENSSL_CONFIG_FILE')) {
+            $configArgs['config'] = env('WEB_TOKEN_JWT_FRAMEWORK_USE_OPENSSL_CONFIG_FILE');
+        }
+        $key = openssl_pkey_new($configArgs);
         if ($key === false) {
             throw new RuntimeException('Unable to create the key');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | <!-- see below -->
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT


The function `openssl_pkey_new` will always return false in windows unless you provide `config` on the `options` parameter.
https://www.php.net/manual/en/function.openssl-pkey-new.php#123410